### PR TITLE
build(makefile): add a formatting rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
         steps:
             - name: Checkout the repository
               uses: actions/checkout@v3
+            - run: make format && git diff --quiet
             - run: TOOLS_PATH=/home/ubuntu/dev/tools make
             - run: make cppcheck
             

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ CC = $(MSPGCC_BIN_DIR)/msp430-elf-gcc
 RM = rm
 DEBUG = LD_LIBRARY_PATH=$(DEBUG_DRIVERS_DIR) $(DEBUG_BIN_DIR)/mspdebug
 CPPCHECK = cppcheck
+FORMAT = clang-format-12
 
 # Files
 TARGET = $(BIN_DIR)/nsumo
@@ -62,7 +63,7 @@ $(OBJ_DIR)/%.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $^
 
 # Phonies
-.PHONY: all clean flash cppcheck
+.PHONY: all clean flash cppcheck format
 
 all: $(TARGET)
 
@@ -78,3 +79,6 @@ cppcheck:
 	-I $(INCLUDE_DIRS) \
 	$(SOURCES) \
 	-i external/printf
+
+format:
+	@$(FORMAT) -i $(SOURCES)

--- a/src/app/drive.c
+++ b/src/app/drive.c
@@ -1,6 +1,5 @@
 #include "drive.h"
 
-void drive_init(void)
-{
+void drive_init(void) {
     // TODO: implement
 }

--- a/src/app/enemy.c
+++ b/src/app/enemy.c
@@ -1,6 +1,5 @@
 #include "enemy.h"
 
-void enemy_init(void)
-{
+void enemy_init(void) {
     // TODO: implement
 }

--- a/src/drivers/i2c.c
+++ b/src/drivers/i2c.c
@@ -1,6 +1,5 @@
 #include "i2c.h"
 
-void i2c_init(void)
-{
+void i2c_init(void) {
     // TODO: implement
 }

--- a/src/drivers/uart.c
+++ b/src/drivers/uart.c
@@ -1,6 +1,5 @@
 #include "uart.h"
 
-void uart_init(void)
-{
-    //TODO: implement
+void uart_init(void) {
+    // TODO: implement
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,11 +1,10 @@
-#include "drivers/uart.h"
-#include "drivers/i2c.h"
 #include "app/drive.h"
 #include "app/enemy.h"
+#include "drivers/i2c.h"
+#include "drivers/uart.h"
 
-int main(void)
-{
-    //TODO: these are just to test build
+int main(void) {
+    // TODO: these are just to test build
     uart_init();
     i2c_init();
     enemy_init();

--- a/tools/dockerfile
+++ b/tools/dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 # Install necessary packages
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update \
-    && apt-get install -y wget bzip2 make unzip cppcheck
+    && apt-get install -y wget bzip2 make unzip cppcheck clang-format-12 git
 
 # Create a non-root user named "ubuntu"
 # But put in root group since GitHub actions needs permissions


### PR DESCRIPTION
All the code in this project should be formatted with the auto-formatter clang-format. Add a Makefile rule to make it easy to format all files in one go from the commandline. There was already a .clang-format config file added previously