### PR TITLE
fix(makefile): reduce cppcheck execution time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,19 @@ HEADERS = \
 OBJECT_NAMES = $(SOURCES:.c=.o)
 OBJECTS = $(patsubst %,$(OBJ_DIR)/%,$(OBJECT_NAMES))
 
+# Static Analysis
+## Don't check the msp430 helper headers (they have a lot of ifdefs)
+CPPCHECK_INCLUDES = ./src
+CPPCHECK_IGNORE = external/printf
+CPPCHECK_FLAGS = \
+	--quiet --enable=all --error-exitcode=1 \
+	--inline-suppr \
+	--suppress=missingIncludeSystem \
+	--suppress=unmatchedSuppression \
+	--suppress=unusedFunction \
+	$(addprefix -I, $(CPPCHECK_INCLUDES)) \
+	$(addprefix -i, $(CPPCHECK_IGNORE))
+
 # Flags
 MCU = msp430g2553
 WFLAGS = -Wall -Wextra -Werror -Wshadow
@@ -70,17 +83,13 @@ $(OBJ_DIR)/%.o: %.c
 all: $(TARGET)
 
 clean:
-	$(RM) -r $(BUILD_DIR)
+	$(RM) -rf $(BUILD_DIR)
 
 flash: $(TARGET) 
-	$(DEBUG) tilib "prog $(TARGET)"
+	@$(DEBUG) tilib "prog $(TARGET)"
 
 cppcheck:
-	@$(CPPCHECK) --quiet --enable=all --error-exitcode=1 \
-	--inline-suppr \
-	-I $(INCLUDE_DIRS) \
-	$(SOURCES) \
-	-i external/printf
+	@$(CPPCHECK) $(CPPCHECK_FLAGS) $(SOURCES)
 
 format:
 	@$(FORMAT) -i $(SOURCES) $(HEADERS)


### PR DESCRIPTION
There is a lot of ifdefs in the support header file msp430.h provided by TI. This slows down cppcheck because it checks all the define combinations. There is no need to check this file, so exclude it from the list of cppcheck files. Suppress the error about missing system includes (ignores standard include <>) and suppress errors about unmatched suppressions as well as unused functions.

Also
* Break the cppcheck rule into variables
* Add -f flag to "clean" to return ok even if build/ doesn't exist