### PR TITLE
feat(drivers): implement IO handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ FORMAT = clang-format-12
 TARGET = $(BIN_DIR)/nsumo
 
 SOURCES_WITH_HEADERS = \
+			 src/drivers/mcu_init.c \
 			 src/drivers/io.c \
 			 src/app/drive.c  \
 			 src/app/enemy.c \

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -1,32 +1,122 @@
 #include "drivers/io.h"
 #include "common/defines.h"
 
+#include <msp430.h>
+#include <stdint.h>
+
+#if defined(LAUNCHPAD)
+#define IO_PORT_CNT (2u)
+#elif defined(NSUMO)
+#define IO_PORT_CNT (3u)
+#endif
+#define IO_PIN_CNT_PER_PORT (8u)
+
+/* Be a little smart here about how to extract the port and pin bit
+ * from the enum io_generic_e (and io_e). Enums are represented as
+ * 16-bit by default on MSP430, so given that the pins are ordered
+ * in increasing order (see io_generic_e), and that there are 3 ports
+ * and 8 pins, the enum value can be viewed as:
+ * [ Zeros (11-bits) | Port (2 bits) | pin (3 bits) ] */
+#define IO_PORT_OFFSET (3u)
+#define IO_PORT_MASK (0x3u << IO_PORT_OFFSET)
+#define IO_PIN_MASK (0x7u)
+
+static inline uint8_t io_port(io_e io) { return (io & IO_PORT_MASK) >> IO_PORT_OFFSET; }
+
+static inline uint8_t io_pin_idx(io_e io) { return io & IO_PIN_MASK; }
+
+static inline uint8_t io_pin_bit(io_e io) { return 1 << io_pin_idx(io); }
+
+/* TI's helper header (msp430.h) provides defines/variables for accessing the
+ * registers, and the address of these are resolved during linking. For cleaner
+ * code, smaller executable, and to avoid mapping between IO_PORT-enum and these
+ * variables using if/switch-statements, store the addresses in arrays and access
+ * them through array indexing. */
+#if defined(LAUNCHPAD)
+static volatile uint8_t* const port_dir_regs[IO_PORT_CNT]  = {&P1DIR, &P2DIR};
+static volatile uint8_t* const port_ren_regs[IO_PORT_CNT]  = {&P1REN, &P2REN};
+static volatile uint8_t* const port_out_regs[IO_PORT_CNT]  = {&P1OUT, &P2OUT};
+static volatile uint8_t* const port_in_regs[IO_PORT_CNT]   = {&P1IN, &P2IN};
+static volatile uint8_t* const port_sel1_regs[IO_PORT_CNT] = {&P1SEL, &P2SEL};
+static volatile uint8_t* const port_sel2_regs[IO_PORT_CNT] = {&P1SEL2, &P2SEL2};
+#elif defined(NSUMO)
+static volatile uint8_t* const port_dir_regs[IO_PORT_CNT]  = {&P1DIR, &P2DIR, &P3DIR};
+static volatile uint8_t* const port_ren_regs[IO_PORT_CNT]  = {&P1REN, &P2REN, &P3REN};
+static volatile uint8_t* const port_out_regs[IO_PORT_CNT]  = {&P1OUT, &P2OUT, &P3OUT};
+static volatile uint8_t* const port_in_regs[IO_PORT_CNT]   = {&P1IN, &P2IN, &P3IN};
+static volatile uint8_t* const port_sel1_regs[IO_PORT_CNT] = {&P1SEL, &P2SEL, &P3SEL};
+static volatile uint8_t* const port_sel2_regs[IO_PORT_CNT] = {&P1SEL2, &P2SEL2, &P3SEL2};
+#endif
+
+void io_configure(io_e io, const struct io_config* config) {
+    io_set_select(io, config->select);
+    io_set_direction(io, config->dir);
+    io_set_out(io, config->out);
+    io_set_resistor(io, config->resistor);
+}
+
 void io_set_select(io_e io, io_select_e select) {
-    UNUSED(io);
-    UNUSED(select);
-    // TODO: Implement
+    const uint8_t port = io_port(io);
+    const uint8_t pin  = io_pin_bit(io);
+    switch (select) {
+    case IO_SELECT_GPIO:
+        *port_sel1_regs[port] &= ~pin;
+        *port_sel2_regs[port] &= ~pin;
+        break;
+    case IO_SELECT_ALT1:
+        *port_sel1_regs[port] |= pin;
+        *port_sel2_regs[port] &= ~pin;
+        break;
+    case IO_SELECT_ALT2:
+        *port_sel1_regs[port] &= ~pin;
+        *port_sel2_regs[port] |= pin;
+        break;
+    case IO_SELECT_ALT3:
+        *port_sel1_regs[port] |= pin;
+        *port_sel2_regs[port] |= pin;
+        break;
+    }
 }
 
 void io_set_direction(io_e io, io_dir_e direction) {
-    UNUSED(io);
-    UNUSED(direction);
-    // TODO: Implement
+    const uint8_t port = io_port(io);
+    const uint8_t pin  = io_pin_bit(io);
+    switch (direction) {
+    case IO_DIR_OUTPUT:
+        *port_dir_regs[port] |= pin;
+        break;
+    case IO_DIR_INPUT:
+        *port_dir_regs[port] &= ~pin;
+        break;
+    }
 }
 
 void io_set_resistor(io_e io, io_resistor_e resistor) {
-    UNUSED(io);
-    UNUSED(resistor);
-    // TODO: Implement
+    const uint8_t port = io_port(io);
+    const uint8_t pin  = io_pin_bit(io);
+    switch (resistor) {
+    case IO_RESISTOR_ENABLED:
+        *port_ren_regs[port] |= pin;
+        break;
+    case IO_RESISTOR_DISABLED:
+        *port_ren_regs[port] &= ~pin;
+        break;
+    }
 }
 
 void io_set_out(io_e io, io_out_e out) {
-    UNUSED(io);
-    UNUSED(out);
-    // TODO: Implement
+    const uint8_t port = io_port(io);
+    const uint8_t pin  = io_pin_bit(io);
+    switch (out) {
+    case IO_OUT_HIGH:
+        *port_out_regs[port] |= pin;
+        break;
+    case IO_OUT_LOW:
+        *port_out_regs[port] &= ~pin;
+        break;
+    }
 }
 
 io_in_e io_get_input(io_e io) {
-    UNUSED(io);
-    // TODO: Implement
-    return 0;
+    return (*port_in_regs[io_port(io)] & io_pin_bit(io)) ? IO_IN_HIGH : IO_IN_LOW;
 }

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -3,54 +3,64 @@
 
 /* IO pins handling including pinmapping, initialization, and configuration.
  * This wraps the more crude register defines provided in the headers from
- * Texas instruments */
+ * Texas Instruments */
 
 // TODO: Improve multiple HW targets handling
 #define LAUNCHPAD
 
+// clang-format off
+typedef enum {
+    IO_10, IO_11, IO_12, IO_13, IO_14, IO_15, IO_16, IO_17,
+    IO_20, IO_21, IO_22, IO_23, IO_24, IO_25, IO_26, IO_27,
+#if defined(NSUMO)
+    IO_30, IO_31, IO_32, IO_33, IO_34, IO_35, IO_36, IO_37,
+#endif
+} io_generic_e;
+// clang-format on
+
 typedef enum {
 #if defined(LAUNCHPAD)  // Launchpad (MSP430G2553IN20)
-    IO_TEST_LED,
-    IO_UART_RXD,
-    IO_UART_TXD,
-    IO_UNUSED_1,
-    IO_UNUSED_2,
-    IO_UNUSED_3,
-    IO_UNUSED_4,
-    IO_UNUSED_5,
-    IO_UNUSED_6,
-    IO_UNUSED_7,
-    IO_UNUSED_8,
-    IO_UNUSED_9,
-    IO_UNUSED_10,
-    IO_UNUSED_11,
-    IO_UNUSED_12,
-    IO_UNUSED_13,
-#elif defined(NSUMO)  // Nsumo rev2 (MSP430G2553IPW28)
-    IO_LINE_DETECT_FRONT_RIGHT,
-    IO_UART_RXD,
-    IO_UART_TXD,
-    IO_LINE_DETECT_FRONT_LEFT,
-    IO_LINE_DETECT_BACK_LEFT,
-    IO_LINE_DETECT_BACK_RIGHT,
-    IO_I2C_SCL,
-    IO_I2C_SDA,
-    IO_IR_REMOTE,
-    IO_RANGE_SENSOR_FRONT_INT,
-    IO_XSHUT_FRONT,
-    IO_UNUSED_1,
-    IO_MOTORS_LEFT_CC_2,
-    IO_MOTORS_LEFT_CC_1,
-    IO_TEST_LED,
-    IO_MOTORS_RIGHT_CC_2,
-    IO_XSHUT_FRONT_RIGHT,
-    IO_XSHUT_RIGHT,
-    IO_XSHUT_FRONT_LEFT,
-    IO_XSHUT_LEFT,
-    IO_UNUSED_2,
-    IO_PWM_MOTORS_LEFT,
-    IO_PWM_MOTORS_RIGHT,
-    IO_MOTORS_RIGHT_CC_1,
+    IO_TEST_LED  = IO_10,
+    IO_UART_RXD  = IO_11,
+    IO_UART_TXD  = IO_12,
+    IO_UNUSED_1  = IO_13,
+    IO_UNUSED_2  = IO_14,
+    IO_UNUSED_3  = IO_15,
+    IO_UNUSED_4  = IO_16,
+    IO_UNUSED_5  = IO_17,
+    IO_UNUSED_6  = IO_20,
+    IO_UNUSED_7  = IO_21,
+    IO_UNUSED_8  = IO_22,
+    IO_UNUSED_9  = IO_23,
+    IO_UNUSED_10 = IO_24,
+    IO_UNUSED_11 = IO_25,
+    IO_UNUSED_12 = IO_26,
+    IO_UNUSED_13 = IO_27,
+#elif defined(NSUMO)  // Nsumo rev 2 (MSP430G2553IPW28)
+    IO_LINE_DETECT_FRONT_RIGHT = IO_10,
+    IO_UART_RXD                = IO_11,
+    IO_UART_TXD                = IO_12,
+    IO_LINE_DETECT_FRONT_LEFT  = IO_13,
+    IO_LINE_DETECT_BACK_LEFT   = IO_14,
+    IO_LINE_DETECT_BACK_RIGHT  = IO_15,
+    IO_I2C_SCL                 = IO_16,
+    IO_I2C_SDA                 = IO_17,
+    IO_IR_REMOTE               = IO_20,
+    IO_RANGE_SENSOR_FRONT_INT  = IO_21,
+    IO_XSHUT_FRONT             = IO_22,
+    IO_UNUSED_1                = IO_23,
+    IO_MOTORS_LEFT_CC_2        = IO_24,
+    IO_MOTORS_LEFT_CC_1        = IO_25,
+    IO_TEST_LED                = IO_26,
+    IO_MOTORS_RIGHT_CC_2       = IO_27,
+    IO_XSHUT_FRONT_RIGHT       = IO_30,
+    IO_XSHUT_RIGHT             = IO_31,
+    IO_XSHUT_FRONT_LEFT        = IO_32,
+    IO_XSHUT_LEFT              = IO_33,
+    IO_UNUSED_2                = IO_34,
+    IO_PWM_MOTORS_LEFT         = IO_35,
+    IO_PWM_MOTORS_RIGHT        = IO_36,
+    IO_MOTORS_RIGHT_CC_1       = IO_37,
 #endif
 } io_e;
 
@@ -81,12 +91,18 @@ typedef enum {
     IO_IN_HIGH,
 } io_in_e;
 
-// TODO: structs
+struct io_config {
+    io_select_e   select;
+    io_resistor_e resistor;
+    io_dir_e      dir;
+    io_out_e      out;
+};
 
+void    io_configure(io_e io, const struct io_config* config);
 void    io_set_select(io_e io, io_select_e select);
 void    io_set_direction(io_e io, io_dir_e direction);
 void    io_set_resistor(io_e io, io_resistor_e resistor);
 void    io_set_out(io_e io, io_out_e out);
 io_in_e io_get_input(io_e io);
 
-#endif
+#endif  // IO_H

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -1,0 +1,12 @@
+#include "drivers/mcu_init.h"
+#include "drivers/io.h"
+#include <msp430.h>
+
+/* Watchdog is enabled by default and will reset the microcontroller repeatedly if not
+ * explicitly stopped */
+static void watchdog_stop(void) { WDTCTL = WDTPW + WDTHOLD; }
+
+void mcu_init(void) {
+    // Must stop watchdog first before anything else
+    watchdog_stop();
+}

--- a/src/drivers/mcu_init.h
+++ b/src/drivers/mcu_init.h
@@ -1,0 +1,9 @@
+#ifndef MCU_INIT_H
+#define MCU_INIT_H
+
+/* Initialization of common microcontroller functionality that affects all peripherals
+ * (e.g. watchdog, clocks, pins) */
+
+void mcu_init(void);
+
+#endif  // MCU_INIT_H

--- a/src/main.c
+++ b/src/main.c
@@ -1,19 +1,117 @@
+#include "drivers/io.h"
+#include "drivers/mcu_init.h"
 #include <msp430.h>
 
-static void test_blink_led(void) {
-    // TODO: Use io functions
-    P1DIR |= BIT0;
-    volatile unsigned int i;  // volatile to prevent optimization
+static void test_setup(void) { mcu_init(); }
+
+/*
+// TODO: Move to test file
+static void test_blink_led(void)
+{
+    test_setup();
+    // TODO: Replace with LED driver
+    const struct io_config led_config =
+    {
+        .dir = IO_DIR_OUTPUT,
+        .select = IO_SELECT_GPIO,
+        .resistor = IO_RESISTOR_DISABLED,
+        .out = IO_OUT_LOW
+    };
+    io_configure(IO_TEST_LED, &led_config);
+    io_out_e out = IO_OUT_LOW;
     while (1) {
-        P1OUT ^= BIT0;
-        for (i = 1000; i > 0; i--) {
-        }  // delay
+        out = (out == IO_OUT_LOW) ? IO_OUT_HIGH : IO_OUT_LOW;
+        io_set_out(IO_TEST_LED, out);
+        __delay_cycles(250000); // 250 ms
+    }
+}
+*/
+
+/*
+// Configure all pins as output and then toggle them in a loop. Verify with a logic analyzer.
+// TODO: Move to test file
+static void test_launchpad_io_pins_output(void)
+{
+    test_setup();
+    const struct io_config output_config = { .select = IO_SELECT_GPIO,
+                                            .resistor = IO_RESISTOR_DISABLED,
+                                            .dir = IO_DIR_OUTPUT,
+                                            .out = IO_OUT_LOW };
+
+    // Configure all pins as output
+    for (io_generic_e io = IO_10; io <= IO_27; io++)
+    {
+        io_configure(io, &output_config);
+    }
+    while (1) {
+        for (io_generic_e io = IO_10; io <= IO_27; io++) {
+            io_set_out(io, IO_OUT_HIGH);
+            __delay_cycles(10000);
+            io_set_out(io, IO_OUT_LOW);
+        }
+    }
+}
+*/
+
+/* Configure all pins except one (pin 1.0) as input with internal pull-up resistors. Configure
+ * the exception (pin 1.0) as output to control an LED. Verify by pulling each pin down in
+ * increasing order with an external pull-down resistor. LED state changes when the right pin is
+ * pulled down. Once all pins have been verified OK, the LED blinks repeatedly.
+ *
+ * Note, the pins are configured with internal pull-up resistors (instead of pull-down) because
+ * some pins on the LAUNCHPAD are already pulled up by external circuitry */
+// TODO: Move to test file
+static void test_launchpad_io_pins_input(void) {
+    test_setup();
+    const struct io_config input_config = {
+        .select   = IO_SELECT_GPIO,
+        .resistor = IO_RESISTOR_ENABLED,
+        .dir      = IO_DIR_INPUT,
+        .out      = IO_OUT_HIGH  // pull-up
+    };
+
+    // TODO: Replace with LED driver
+    const struct io_config led_config = {.select   = IO_SELECT_GPIO,
+                                         .resistor = IO_RESISTOR_DISABLED,
+                                         .dir      = IO_DIR_OUTPUT,
+                                         .out      = IO_OUT_LOW};
+    const io_generic_e     io_led     = IO_10;
+
+    // Configure all pins as input
+    for (io_generic_e io = IO_10; io <= IO_27; io++) {
+        io_configure(io, &input_config);
+    }
+
+    io_configure(io_led, &led_config);
+
+    for (io_generic_e io = IO_10; io <= IO_27; io++) {
+        if (io == io_led) {
+            continue;
+        }
+        io_set_out(io_led, IO_OUT_HIGH);
+        // Wait for user to pull pin low
+        while (io_get_input(io) == IO_IN_HIGH) {
+            __delay_cycles(100000);  // 100 ms
+        }
+        io_set_out(io_led, IO_OUT_LOW);
+        // Wait for user to disconnect
+        while (io_get_input(io) == IO_IN_LOW) {
+            __delay_cycles(100000);  // 100 ms
+        }
+    }
+
+    // Blink LED when test is done
+    while (1) {
+        io_set_out(io_led, IO_OUT_HIGH);
+        __delay_cycles(500000);  // 500 ms
+        io_set_out(io_led, IO_OUT_LOW);
+        __delay_cycles(2000000);  // 2000 ms
     }
 }
 
 int main(void) {
-    // TODO: Move to mcu_init
-    WDTCTL = WDTPW + WDTHOLD;  // stop watchdog timer
-    test_blink_led();
+    // test_blink_led();
+    // test_launchpad_io_pins_output();
+    test_launchpad_io_pins_input();
     return 0;
 }


### PR DESCRIPTION
The pinmapping for the Launchpad and the actual PCB (Nsumo) are represented with an enum (io_e). Create a second enum (io_generic_e), define macros, and static register arrays (e.g. port_dir_regs) to map the enum values to the corresponding registers in a space-efficient way. Implement the individual functions to select function, set resistor, direction, and output. The result is an abstraction that's much nicer than directly accessing the crude register variables from TI.