### PR TITLE
feat(drivers): IO pins initialization

### DIFF
--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -2,5 +2,6 @@
 #define DEFINES_H
 
 #define UNUSED(x) (void)(x)
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
 #endif

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -48,11 +48,94 @@ static volatile uint8_t* const port_sel1_regs[IO_PORT_CNT] = {&P1SEL, &P2SEL, &P
 static volatile uint8_t* const port_sel2_regs[IO_PORT_CNT] = {&P1SEL2, &P2SEL2, &P3SEL2};
 #endif
 
+/* Unused pins should be
+ * Switched to port function, output direction or input with pullup/pulldown enabled
+ * according to the dataset (2.5). Importantly, they should not be left as floating
+ * inputs because that leads to unpredictable (noise) current consumption. I choose to
+ * configure them as output (instead of input) to lower the rist of short-circuits, and
+ * pull them down. */
+#define UNUSED_CONFIG                                                                              \
+    { IO_SELECT_GPIO, IO_RESISTOR_ENABLED, IO_DIR_OUTPUT, IO_OUT_LOW }
+
 void io_configure(io_e io, const struct io_config* config) {
     io_set_select(io, config->select);
     io_set_direction(io, config->dir);
     io_set_out(io, config->out);
     io_set_resistor(io, config->resistor);
+}
+
+// This array holds the initial configuration for all IO pins.
+static const struct io_config io_initial_config[IO_PORT_CNT * IO_PIN_CNT_PER_PORT] = {
+    [IO_TEST_LED] = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+
+    /* UART RX/TX
+     * Resistor: Not needed (pulled by transmitter/receiver)
+     * Direction: Not applicable
+     * Output: Not applicable */
+    [IO_UART_RXD] = {IO_SELECT_ALT3, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_UART_TXD] = {IO_SELECT_ALT3, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+
+#if defined(LAUNCHPAD)
+    // Unused pins
+    [IO_UNUSED_1]  = UNUSED_CONFIG,
+    [IO_UNUSED_2]  = UNUSED_CONFIG,
+    [IO_UNUSED_3]  = UNUSED_CONFIG,
+    [IO_UNUSED_4]  = UNUSED_CONFIG,
+    [IO_UNUSED_5]  = UNUSED_CONFIG,
+    [IO_UNUSED_6]  = UNUSED_CONFIG,
+    [IO_UNUSED_7]  = UNUSED_CONFIG,
+    [IO_UNUSED_8]  = UNUSED_CONFIG,
+    [IO_UNUSED_9]  = UNUSED_CONFIG,
+    [IO_UNUSED_10] = UNUSED_CONFIG,
+    [IO_UNUSED_11] = UNUSED_CONFIG,
+    [IO_UNUSED_12] = UNUSED_CONFIG,
+    [IO_UNUSED_13] = UNUSED_CONFIG,
+#elif defined(NSUMO)
+    // Input (no resistor required according to datasheet of IR receiver)
+    [IO_IR_REMOTE] = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_LOW},
+
+    /* I2C clock/data
+     * Resistor: Disabled (there are external pull-up resistors)
+     * Direction: Not applicable
+     * Output: Not applicable */
+    [IO_I2C_SCL] = {IO_SELECT_ALT3, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_I2C_SDA] = {IO_SELECT_ALT3, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+
+    // Output
+    [IO_MOTORS_LEFT_CC_1]  = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_MOTORS_LEFT_CC_2]  = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_MOTORS_RIGHT_CC_1] = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_MOTORS_RIGHT_CC_2] = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+
+    // Output driven by A0, direction must be set to output
+    [IO_PWM_MOTORS_LEFT]  = {IO_SELECT_ALT1, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_PWM_MOTORS_RIGHT] = {IO_SELECT_ALT1, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+
+    /* Input
+     * Range sensor provides open-drain output and should be connected to an external pull-up
+     * resistor, but I missed that on the PCB, so use the internal pull-up instead. */
+    [IO_RANGE_SENSOR_FRONT_INT] = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_HIGH},
+
+    // Outputs
+    [IO_XSHUT_FRONT]       = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_XSHUT_FRONT_LEFT]  = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_XSHUT_RIGHT]       = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_XSHUT_LEFT]        = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_XSHUT_FRONT_RIGHT] = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+
+    // Overriden by ADC, so just default it to floating input here
+    [IO_LINE_DETECT_FRONT_RIGHT] = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_LOW},
+    [IO_LINE_DETECT_FRONT_LEFT]  = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_LOW},
+    [IO_LINE_DETECT_BACK_RIGHT]  = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_LOW},
+    [IO_LINE_DETECT_BACK_LEFT]   = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_LOW},
+#endif
+};
+
+void io_init(void) {
+    // TODO: Loop initialize all pins
+    for (io_e io = (io_e)IO_10; io < ARRAY_SIZE(io_initial_config); io++) {
+        io_configure(io, &io_initial_config[io]);
+    }
 }
 
 void io_set_select(io_e io, io_select_e select) {

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -98,6 +98,7 @@ struct io_config {
     io_out_e      out;
 };
 
+void    io_init(void);
 void    io_configure(io_e io, const struct io_config* config);
 void    io_set_select(io_e io, io_select_e select);
 void    io_set_direction(io_e io, io_dir_e direction);

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -9,4 +9,5 @@ static void watchdog_stop(void) { WDTCTL = WDTPW + WDTHOLD; }
 void mcu_init(void) {
     // Must stop watchdog first before anything else
     watchdog_stop();
+    io_init();
 }


### PR DESCRIPTION
Create an array to hold the initial configuration for all IO pins and configure them at boot. Configure the unused pins as recommended by the datasheet. Most pins will keep their configuration throughout, and won't need to be reconfigured in the drivers to come.