### PR TITLE
feat(assert): assert handler and led driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ CPPCHECK_FLAGS = \
 # Flags
 MCU = msp430g2553
 WFLAGS = -Wall -Wextra -Werror -Wshadow
-CFLAGS = -mmcu=$(MCU) $(WFLAGS) $(addprefix -I,$(INCLUDE_DIRS)) $(DEFINES) -Og -g
+CFLAGS = -mmcu=$(MCU) $(WFLAGS) -fshort-enums $(addprefix -I,$(INCLUDE_DIRS)) $(DEFINES) -Og -g
 LDFLAGS = -mmcu=$(MCU) $(DEFINES) $(addprefix -L,$(LIB_DIRS))
 
 #Build

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,10 @@ FORMAT = clang-format-12
 TARGET = $(BUILD_DIR)/$(TARGET_NAME)
 
 SOURCES_WITH_HEADERS = \
+			 src/common/assert_handler.c \
 			 src/drivers/mcu_init.c \
 			 src/drivers/io.c \
+			 src/drivers/led.c \
 			 src/app/drive.c  \
 			 src/app/enemy.c \
 

--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -1,0 +1,38 @@
+#include "common/assert_handler.h"
+#include "common/defines.h"
+#include <msp430.h>
+
+/* The TI compiler provides intrinsic support for calling a specific opcode, which means
+ * you can write __op_code(0x4343) to trigger a software breakpoint (when LAUNCHPAD FET
+ * debugger is attached). MSP430-GCC does not have this intrinsic, but 0x4343 corresponds
+ * to assembly instruction "CLR.B R3". */
+#define BREAKPOINT __asm volatile("CLR.B R3");
+
+/* Minimize code dependency in this function to reduce the risk of accidently calling
+ * a function with an assert in it, which would cause the assert_handler to be called
+ * recursively until stack overflow. */
+void assert_handler(void) {
+    // TODO: Turn off motors ("safe state")
+    // TODO: Trace to console
+
+    BREAKPOINT
+
+    // Configure TEST LED pin on LAUNCHPAD
+    P1SEL &= ~(BIT0);
+    P1SEL2 &= ~(BIT0);
+    P1DIR |= BIT0;
+    P1REN &= ~(BIT0);
+
+    // Confgure TEST LED pin on NSUMO
+    P2SEL &= ~(BIT6);
+    P2SEL2 &= ~(BIT6);
+    P2DIR |= BIT6;
+    P2REN &= ~(BIT6);
+
+    while (1) {
+        // Blink LED on both targets in case the wrong target was flashed
+        P1OUT ^= BIT0;
+        P2OUT ^= BIT6;
+        BUSY_WAIT_ms(250);
+    };
+}

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -1,0 +1,14 @@
+#ifndef ASSERT_HANDLER_H
+
+// Assert implementation suitable for a microcontroller
+
+#define ASSERT(expression)                                                                         \
+    do {                                                                                           \
+        if (!(expression)) {                                                                       \
+            assert_handler();                                                                      \
+        }                                                                                          \
+    } while (0)
+
+void assert_handler(void);
+
+#endif

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -4,4 +4,9 @@
 #define UNUSED(x) (void)(x)
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
+// TODO: Change clock rate from 1 MHz to 16 Mhz
+#define CYCLES_1MHZ (1000000u)
+#define ms_TO_CYCLES(ms) ((CYCLES_1MHZ / 1000) * ms)
+#define BUSY_WAIT_ms(ms) (__delay_cycles(ms_TO_CYCLES(ms)))
+
 #endif

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -3,6 +3,7 @@
 
 #include <msp430.h>
 #include <stdint.h>
+#include <assert.h>
 
 #if defined(LAUNCHPAD)
 #define IO_PORT_CNT (2u)
@@ -12,11 +13,12 @@
 #define IO_PIN_CNT_PER_PORT (8u)
 
 /* Be a little smart here about how to extract the port and pin bit
- * from the enum io_generic_e (and io_e). Enums are represented as
- * 16-bit by default on MSP430, so given that the pins are ordered
- * in increasing order (see io_generic_e), and that there are 3 ports
+ * from the enum io_generic_e (and io_e). With compiler flag "-fshort-enums",
+ * the enums are represented as single byte (8-bit), so given that the pins
+ * are ordered in increasing order (see io_generic_e), and that there are 3 ports
  * and 8 pins, the enum value can be viewed as:
  * [ Zeros (11-bits) | Port (2 bits) | pin (3 bits) ] */
+static_assert(sizeof(io_generic_e)==1, "Unexpected size, -fshort-enums missing?");
 #define IO_PORT_OFFSET (3u)
 #define IO_PORT_MASK (0x3u << IO_PORT_OFFSET)
 #define IO_PIN_MASK (0x7u)

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -1,9 +1,10 @@
 #include "drivers/io.h"
+#include "common/assert_handler.h"
 #include "common/defines.h"
 
+#include <assert.h>
 #include <msp430.h>
 #include <stdint.h>
-#include <assert.h>
 
 #if defined(LAUNCHPAD)
 #define IO_PORT_CNT (2u)
@@ -18,7 +19,7 @@
  * are ordered in increasing order (see io_generic_e), and that there are 3 ports
  * and 8 pins, the enum value can be viewed as:
  * [ Zeros (11-bits) | Port (2 bits) | pin (3 bits) ] */
-static_assert(sizeof(io_generic_e)==1, "Unexpected size, -fshort-enums missing?");
+static_assert(sizeof(io_generic_e) == 1, "Unexpected size, -fshort-enums missing?");
 #define IO_PORT_OFFSET (3u)
 #define IO_PORT_MASK (0x3u << IO_PORT_OFFSET)
 #define IO_PIN_MASK (0x7u)
@@ -143,21 +144,11 @@ static hw_type_e io_detect_hw_type(void) {
 void io_init(void) {
 
 #if defined(NSUMO)
-    // TODO: Assert
-    if (io_detect_hw_type() != HW_TYPE_NSUMO) {
-        while (1) {
-        }
-    }
+    ASSERT(io_detect_hw_type() == HW_TYPE_NSUMO);
 #elif defined(LAUNCHPAD)
-    // TODO: Assert
-    if (io_detect_hw_type() != HW_TYPE_LAUNCHPAD) {
-        while (1) {
-        }
-    }
+    ASSERT(io_detect_hw_type() == HW_TYPE_LAUNCHPAD);
 #else
-    // TODO: Assert
-    while (1) {
-    }
+    ASSERT(0);
 #endif
     for (io_e io = (io_e)IO_10; io < ARRAY_SIZE(io_initial_config); io++) {
         io_configure(io, &io_initial_config[io]);

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -1,6 +1,8 @@
 #ifndef IO_H
 #define IO_H
 
+#include <stdbool.h>
+
 /* IO pins handling including pinmapping, initialization, and configuration.
  * This wraps the more crude register defines provided in the headers from
  * Texas Instruments */
@@ -68,10 +70,7 @@ typedef enum {
     IO_SELECT_ALT3,
 } io_select_e;
 
-typedef enum {
-    IO_DIR_OUTPUT,
-    IO_DIR_INPUT,
-} io_dir_e;
+typedef enum { IO_DIR_INPUT, IO_DIR_OUTPUT } io_dir_e;
 
 typedef enum {
     IO_RESISTOR_DISABLED,
@@ -97,6 +96,8 @@ struct io_config {
 
 void    io_init(void);
 void    io_configure(io_e io, const struct io_config* config);
+void    io_get_current_config(io_e io, struct io_config* current_config);
+bool    io_config_compare(const struct io_config* cfg1, const struct io_config* cfg2);
 void    io_set_select(io_e io, io_select_e select);
 void    io_set_direction(io_e io, io_dir_e direction);
 void    io_set_resistor(io_e io, io_resistor_e resistor);

--- a/src/drivers/led.c
+++ b/src/drivers/led.c
@@ -1,0 +1,31 @@
+#include "drivers/led.h"
+#include "common/assert_handler.h"
+#include "common/defines.h"
+#include "drivers/io.h"
+#include <stdbool.h>
+
+static const struct io_config led_config = {
+    .select   = IO_SELECT_GPIO,
+    .resistor = IO_RESISTOR_DISABLED,
+    .dir      = IO_DIR_OUTPUT,
+    .out      = IO_OUT_LOW,
+};
+
+static bool initialized = false;
+void        led_init(void) {
+    ASSERT(!initialized);
+    struct io_config current_config;
+    io_get_current_config(IO_TEST_LED, &current_config);
+    ASSERT(io_config_compare(&current_config, &led_config));
+    initialized = true;
+}
+
+void led_set(led_e led, led_state_e state) {
+    ASSERT(initialized);
+    const io_out_e out = (state == LED_STATE_ON) ? IO_OUT_HIGH : IO_OUT_LOW;
+    switch (led) {
+    case LED_TEST:
+        io_set_out(IO_TEST_LED, out);
+        break;
+    }
+}

--- a/src/drivers/led.h
+++ b/src/drivers/led.h
@@ -1,0 +1,14 @@
+#ifndef LED_H
+
+// Simple driver for controlling GPIOs with LEDs connected to them
+
+typedef enum {
+    LED_TEST,
+} led_e;
+
+typedef enum { LED_STATE_OFF, LED_STATE_ON } led_state_e;
+
+void led_init();
+void led_set(led_e led, led_state_e state);
+
+#endif  // LED_H

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,7 @@
+#include "common/assert_handler.h"
+#include "common/defines.h"
 #include "drivers/io.h"
+#include "drivers/led.h"
 #include "drivers/mcu_init.h"
 #include <msp430.h>
 
@@ -7,17 +10,12 @@ static void test_setup(void) { mcu_init(); }
 // TODO: Move to test file
 static void test_blink_led(void) {
     test_setup();
-    // TODO: Replace with LED driver
-    const struct io_config led_config = {.dir      = IO_DIR_OUTPUT,
-                                         .select   = IO_SELECT_GPIO,
-                                         .resistor = IO_RESISTOR_DISABLED,
-                                         .out      = IO_OUT_LOW};
-    io_configure(IO_TEST_LED, &led_config);
-    io_out_e out = IO_OUT_LOW;
+    led_init();
+    led_state_e led_state = LED_STATE_OFF;
     while (1) {
-        out = (out == IO_OUT_LOW) ? IO_OUT_HIGH : IO_OUT_LOW;
-        io_set_out(IO_TEST_LED, out);
-        __delay_cycles(250000);  // 250 ms
+        led_state = (led_state == LED_STATE_OFF) ? LED_STATE_ON : LED_STATE_OFF;
+        led_set(LED_TEST, led_state);
+        BUSY_WAIT_ms(250);
     }
 }
 
@@ -40,7 +38,7 @@ static void test_launchpad_io_pins_output(void)
     while (1) {
         for (io_generic_e io = IO_10; io <= IO_27; io++) {
             io_set_out(io, IO_OUT_HIGH);
-            __delay_cycles(10000);
+            BUSY_WAIT_ms(10);
             io_set_out(io, IO_OUT_LOW);
         }
     }
@@ -55,9 +53,10 @@ static void test_launchpad_io_pins_output(void)
  * Note, the pins are configured with internal pull-up resistors (instead of pull-down) because
  * some pins on the LAUNCHPAD are already pulled up by external circuitry */
 // TODO: Move to test file
-#if 0
+/*
 static void test_launchpad_io_pins_input(void) {
     test_setup();
+    led_init();
     const struct io_config input_config = {
         .select   = IO_SELECT_GPIO,
         .resistor = IO_RESISTOR_ENABLED,
@@ -65,45 +64,36 @@ static void test_launchpad_io_pins_input(void) {
         .out      = IO_OUT_HIGH  // pull-up
     };
 
-    // TODO: Replace with LED driver
-    const struct io_config led_config = {.select   = IO_SELECT_GPIO,
-                                         .resistor = IO_RESISTOR_DISABLED,
-                                         .dir      = IO_DIR_OUTPUT,
-                                         .out      = IO_OUT_LOW};
-    const io_generic_e     io_led     = IO_10;
-
     // Configure all pins as input
     for (io_generic_e io = IO_10; io <= IO_27; io++) {
         io_configure(io, &input_config);
     }
 
-    io_configure(io_led, &led_config);
-
     for (io_generic_e io = IO_10; io <= IO_27; io++) {
-        if (io == io_led) {
+        if (io == (io_generic_e(IO_TEST_LED))) {
             continue;
         }
-        io_set_out(io_led, IO_OUT_HIGH);
+        led_set(LED_TEST, LED_STATE_ON);
         // Wait for user to pull pin low
         while (io_get_input(io) == IO_IN_HIGH) {
-            __delay_cycles(100000);  // 100 ms
+            BUSY_WAIT_ms(100);  // 100 ms
         }
-        io_set_out(io_led, IO_OUT_LOW);
+        led_set(LED_TEST, LED_STATE_OFF);
         // Wait for user to disconnect
         while (io_get_input(io) == IO_IN_LOW) {
-            __delay_cycles(100000);  // 100 ms
+            BUSY_WAIT_ms(100);  // 100 ms
         }
     }
 
     // Blink LED when test is done
     while (1) {
-        io_set_out(io_led, IO_OUT_HIGH);
-        __delay_cycles(500000);  // 500 ms
-        io_set_out(io_led, IO_OUT_LOW);
-        __delay_cycles(2000000);  // 2000 ms
-    } 
+        led_set(LED_TEST, LED_STATE_HIGH);
+        BUSY_WAIT_ms(500);
+        led_set(LED_TEST, LED_STATE_LOW);
+        BUSY_WAIT_ms(2000);
+    }
 }
-#endif
+*/
 
 int main(void) {
     test_blink_led();


### PR DESCRIPTION
Create an assert handler suitable for a microcontroller. Let it trigger a software breakpoint (if the debugger is attached) and then enter an endless while loop blinking the test led. The handler will later be extended with console tracing and turning off the motors.

Also, implement a simple led driver to avoid having to interact with the IO functions directly, but don't use the driver in the assert handler to avoid it from being called recursively.

Finally, wrap the __delay_cycles intrinsic in a new define macro BUSY_WAIT_ms that takes milliseconds (instead of cycles) as argument.