### PR TITLE
feat(drivers): UART driver and ring buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,11 @@ TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
 
 SOURCES_WITH_HEADERS = \
 			 src/common/assert_handler.c \
+			 src/common/ring_buffer.c \
 			 src/drivers/mcu_init.c \
 			 src/drivers/io.c \
 			 src/drivers/led.c \
+			 src/drivers/uart.c \
 			 src/app/drive.c  \
 			 src/app/enemy.c \
 

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -9,6 +9,14 @@
         }                                                                                          \
     } while (0)
 
+#define ASSERT_INTERRUPT(expression)                                                               \
+    do {                                                                                           \
+        if (!(expression)) {                                                                       \
+            while (1)                                                                              \
+                ;                                                                                  \
+        }                                                                                          \
+    } while (0)
+
 void assert_handler(void);
 
 #endif

--- a/src/common/ring_buffer.c
+++ b/src/common/ring_buffer.c
@@ -1,0 +1,28 @@
+#include "common/ring_buffer.h"
+
+void ring_buffer_put(struct ring_buffer* rb, uint8_t data) {
+    rb->buffer[rb->head] = data;
+    rb->head++;
+    // avoid expensive modulo operation
+    // like rb->head = (rb->head + 1)% rb->size
+    if (rb->head == rb->size) {
+        rb->head = 0;
+    }
+}
+uint8_t ring_buffer_get(struct ring_buffer* rb) {
+    const uint8_t data = rb->buffer[rb->tail];
+    rb->tail++;
+    if (rb->tail == rb->size) {
+        rb->tail = 0;
+    }
+    return data;
+}
+uint8_t ring_buffer_peek(const struct ring_buffer* rb) { return rb->buffer[rb->tail]; }
+bool    ring_buffer_empty(const struct ring_buffer* rb) { return rb->head == rb->tail; }
+bool    ring_buffer_full(const struct ring_buffer* rb) {
+    uint8_t idx_after_head = rb->head + 1;
+    if (idx_after_head == rb->size) {
+        idx_after_head = 0;
+    }
+    return idx_after_head == rb->tail;
+}

--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -1,0 +1,23 @@
+#ifndef RING_BUFFER_H
+#define RING_BUFFER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+struct ring_buffer {
+    uint8_t* buffer;
+    uint8_t  size;
+    uint8_t  head;
+    uint8_t  tail;
+};
+
+// Caller must check if full
+void ring_buffer_put(struct ring_buffer* rb, uint8_t data);
+// Caller must check if empty
+uint8_t ring_buffer_get(struct ring_buffer* rb);
+// Caller must check if empty
+uint8_t ring_buffer_peek(const struct ring_buffer* rb);
+bool    ring_buffer_empty(const struct ring_buffer* rb);
+bool    ring_buffer_full(const struct ring_buffer* rb);
+
+#endif  // RING_BUFFER_H

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -12,10 +12,10 @@ static void init_clocks() {
 
     /* Configure the internal oscillator (main clock) to run at 16 MHz.
      * This clock is used as a reference to produce a more stable DCO. */
-    BCSCTL1 |= CALBC1_16MHZ;
+    BCSCTL1 = CALBC1_16MHZ;
 
     // Sets the clock rate of the digitally controlled oscillator (DCO)
-    DCOCTL |= CALDCO_16MHZ;
+    DCOCTL = CALDCO_16MHZ;
 
     /* Set DCO as source for
      * MCLK: Master clock drives the CPU and some peripherals

--- a/src/drivers/uart.c
+++ b/src/drivers/uart.c
@@ -1,0 +1,126 @@
+#include "drivers/uart.h"
+#include "common/assert_handler.h"
+#include "common/ring_buffer.h"
+#include <assert.h>
+#include <msp430.h>
+#include <stdint.h>
+
+#define UART_BUFFER_SIZE (16)
+static uint8_t            buffer[UART_BUFFER_SIZE];
+static struct ring_buffer tx_buffer = {.buffer = buffer, .size = sizeof(buffer)};
+/* Calculate the integer and fractional part of the divisor
+ * N = (Clock source / Desired baudrate)
+ * for Low-Frequency Baud Rate Mode.
+ *
+ * These are used to configure the desired baudrate
+ *
+ * For information on the corresponding transmission error
+ * for common values, please refer to the table provided in
+ * the family user guide (SLAU144K)*/
+
+#define SMCLK (16000000u)
+#define BRCLK (SMCLK)
+#define UART_BAUD_RATE (115200u)
+static_assert(UART_BAUD_RATE < (BRCLK / 3.0f),
+              "Baudrate must be smaller than 1/3 of input clock in Low-frequency Mode");
+#define UART_DIVISOR ((float)BRCLK / UART_BAUD_RATE)
+static_assert(UART_DIVISOR < 0xFFFFu, "Sanity check divisor fits in 16-bit");
+
+#define UART_DIVISOR_INT_16_BIT ((uint16_t)UART_DIVISOR)  // controls the prescalar
+#define UART_DIVISOR_INT_LOW_BYTE (UART_DIVISOR_INT_16_BIT & 0xFF);
+#define UART_DIVISOR_INT_HIGH_BYTE (UART_DIVISOR_INT_16_BIT >> 8);
+#define UART_DIVISOR_FRACTIONAL (UART_DIVISOR - UART_DIVISOR_INT_16_BIT)  // controls the modulator
+// prescalar brings baud rate closer to desire and modulator brings more closer to it.
+#define UART_UCBRS ((uint8_t)(8 * UART_DIVISOR_FRACTIONAL))
+#define UART_UCBRF (0)
+#define UART_UC0S16 (0)
+static_assert(UART_UCBRS < 8, "Sanity check second modulation stage value fits in 3-bit");
+
+static inline void uart_tx_enable_interrupt(void) { UC0IE |= UCA0TXIE; }
+
+static inline void uart_tx_disable_interrupt(void) { UC0IE &= ~UCA0TXIE; }
+
+static inline void uart_tx_clear_interrupt(void) { IFG2 &= ~UCA0TXIFG; }
+
+static void uart_tx_start(void) {
+    if (!(ring_buffer_empty(&tx_buffer))) {
+        UCA0TXBUF = ring_buffer_peek(&tx_buffer);
+    }
+}
+
+__attribute__((interrupt(USCIAB0TX_VECTOR))) void isr_uart_tx() {
+    ASSERT_INTERRUPT(!ring_buffer_empty(&tx_buffer));
+
+    // Remove the transmitted data byte from the buffer
+    ring_buffer_get(&tx_buffer);
+
+    // Clear interrupt here to avoid accidently clearing interrupt for next transmission
+    uart_tx_clear_interrupt();
+
+    if (!ring_buffer_empty(&tx_buffer)) {
+        uart_tx_start();
+    }
+}
+
+static bool initialized = false;
+
+void uart_init(void) {
+    ASSERT(!initialized);
+
+    /* Reset module. It stays in reset until cleared. The module should be in reset
+     *  condition while configuring according to the user guide SLAU144K. */
+    UCA0CTL1 &= UCSWRST;
+    // TODO: configure
+
+    /* Use default (data word length 8 bits, 1 stop bit, no parity bits)
+     * [ Start (1 bit) | Data (8 bits) | Stop (1 bit) ] */
+    UCA0CTL0 = 0;
+
+    // Set SMCLK as clock source which is Sub system clock
+    UCA0CTL1 |= UCSSEL_2;
+
+    // Set clock prescaler to the integer part of divisor N.
+    UCA0BR0 = UART_DIVISOR_INT_LOW_BYTE;
+    UCA0BR1 = UART_DIVISOR_INT_HIGH_BYTE;
+
+    /* Set modulation to account for fractional part of divisor N.
+     * UCA0MCTL = [ UCBRF (4 bits) | UCBRS (3 bits) | UC0516 (1 bit) ] */
+    UCA0MCTL = ((UART_UCBRF << 4) + (UART_UCBRS << 1) + UART_UC0S16);
+
+    // Clear reset to release the module for operation
+    UCA0CTL1 &= ~UCSWRST;
+
+    // Interrupt triggers when TX buffer is empty, which it is after boot, so clear it here.
+    uart_tx_clear_interrupt();
+
+    // Enable TX interrupt
+    UC0IE |= UCA0TXIE;
+
+    initialized = true;
+}
+
+void uart_putchar_interrupt(char c) {
+    // Poll if full
+    while (ring_buffer_full(&tx_buffer))
+        ;
+
+    uart_tx_disable_interrupt();
+    const bool tx_ongoing = !ring_buffer_empty(&tx_buffer);
+    ring_buffer_put(&tx_buffer, c);
+    if (!tx_ongoing) {
+        uart_tx_start();
+    }
+    uart_tx_enable_interrupt();
+    // Some terminals expect line feed (\r) after carriage return (\n) for proper new line
+    if (c == '\n') {
+        uart_putchar_interrupt('\r');
+    }
+}
+
+void uart_print_interrupt(const char* string) {
+    int i = 0;
+    while (string[i] != '\0') {
+        uart_putchar_interrupt(string[i]);
+        i++;
+    }
+}

--- a/src/drivers/uart.h
+++ b/src/drivers/uart.h
@@ -1,0 +1,8 @@
+#ifndef UART_H
+#define UART_H
+
+void uart_init(void);
+// TODO: Replace with printf
+void uart_putchar_interrupt(char c);
+void uart_print_interrupt(const char* string);
+#endif  // UART_H

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -3,6 +3,7 @@
 #include "drivers/io.h"
 #include "drivers/led.h"
 #include "drivers/mcu_init.h"
+#include "drivers/uart.h"
 #include <msp430.h>
 
 SUPPRESS_UNUSED
@@ -133,6 +134,17 @@ static void test_io_interrupt(void)
     io_enable_interrupt(IO_11);
     io_enable_interrupt(IO_20);
     while(1);
+}
+
+SUPPRESS_UNUSED
+static void test_uart(void)
+{
+    test_setup();
+    uart_init();
+    while(1){
+        uart_print_interrupt("UART working\n");
+        BUSY_WAIT_ms(1000);
+    }
 }
 
 int main()


### PR DESCRIPTION
Add a driver for the UART peripheral that can transmit individual characters. Make it interrupt driven and put the characters in a ring buffer that interrupt can feed from. This is going to be used to implement tracing (printf) in the future.

Also, write the calibrated clock values correctly.

This was tested by connecting the Launchpad to a PC via USB-to-UART bridge use terminal.