### PR TITLE
feat(trace): use external printf implementation for trace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
         steps:
             - name: Checkout the repository
               uses: actions/checkout@v3
+              with:
+                submodules: "true"
             - run: make format && git diff --quiet
             - run: TOOLS_PATH=/home/ubuntu/dev/tools make HW=NSUMO
             - run: TOOLS_PATH=/home/ubuntu/dev/tools make HW=LAUNCHPAD

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ CPPCHECK = cppcheck
 FORMAT = clang-format-12
 SIZE = $(MSPGCC_BIN_DIR)/msp430-elf-size
 READELF = $(MSPGCC_BIN_DIR)/msp430-elf-readelf
+ADDR2LINE = $(MSPGCC_BIN_DIR)/msp430-elf-addr2line
 
 # Files
 TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
@@ -140,3 +141,6 @@ size: $(TARGET)
 
 symbols: $(TARGET)
 	@$(READELF) -s $(TARGET) | sort -n -k3
+
+addr2line: $(TARGET)
+	@$(ADDR2LINE) -e $(TARGET) $(ADDR)

--- a/external/printf_config.h
+++ b/external/printf_config.h
@@ -1,0 +1,13 @@
+#ifndef PRINTF_CONFIG_H
+#define PRINTF_CONFIG_H
+
+/* Configuration file for the mpaland printf implementation (see external/printf).
+ * PRINTF_INCLUDE_CONFIG_H must be defined as a compiler switch for this to be picked up */
+
+// Disable everything not used to reduce flash usage
+#define PRINTF_DISABLE_SUPPORT_LONG_LONG
+#define PRINTF_DISABLE_SUPPORT_PTRDIFF_T
+#define PRINTF_DISABLE_SUPPORT_EXPONENTIAL
+#define PRINTF_DISABLE_SUPPORT_FLOAT
+
+#endif  // PRINTF_CONFIG_H

--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -1,5 +1,7 @@
 #include "common/assert_handler.h"
 #include "common/defines.h"
+#include "drivers/uart.h"
+#include "external/printf/printf.h"
 #include <msp430.h>
 
 /* The TI compiler provides intrinsic support for calling a specific opcode, which means
@@ -8,15 +10,20 @@
  * to assembly instruction "CLR.B R3". */
 #define BREAKPOINT __asm volatile("CLR.B R3");
 
-/* Minimize code dependency in this function to reduce the risk of accidently calling
- * a function with an assert in it, which would cause the assert_handler to be called
- * recursively until stack overflow. */
-void assert_handler(void) {
-    // TODO: Turn off motors ("safe state")
-    // TODO: Trace to console
+// Text + Program counter + Null termination
+#define ASSERT_STRING_MAX_SIZE (15u + 6u + 1u)
 
-    BREAKPOINT
+static void assert_trace(uint16_t program_counter) {
+    // UART Tx
+    P1SEL |= BIT1;
+    P1SEL2 |= BIT1;
+    uart_init_assert();
+    char assert_string[ASSERT_STRING_MAX_SIZE];
+    snprintf(assert_string, sizeof(assert_string), "ASSERT 0x%x\n", program_counter);
+    uart_trace_assert(assert_string);
+}
 
+static void assert_blink_led(void) {
     // Configure TEST LED pin on LAUNCHPAD
     P1SEL &= ~(BIT0);
     P1SEL2 &= ~(BIT0);
@@ -35,4 +42,14 @@ void assert_handler(void) {
         P2OUT ^= BIT6;
         BUSY_WAIT_ms(250);
     };
+}
+/* Minimize code dependency in this function to reduce the risk of accidently calling
+ * a function with an assert in it, which would cause the assert_handler to be called
+ * recursively until stack overflow. */
+void assert_handler(uint16_t program_counter) {
+
+    // TODO: Turn off motors ("safe state")
+    BREAKPOINT
+    assert_trace(program_counter);
+    assert_blink_led();
 }

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -1,22 +1,26 @@
 #ifndef ASSERT_HANDLER_H
 
+#include <stdint.h>
+
 // Assert implementation suitable for a microcontroller
 
 #define ASSERT(expression)                                                                         \
     do {                                                                                           \
         if (!(expression)) {                                                                       \
-            assert_handler();                                                                      \
+            uint16_t pc;                                                                           \
+            asm volatile("mov pc, %0" : "=r"(pc));                                                 \
+            assert_handler(pc);                                                                    \
         }                                                                                          \
     } while (0)
 
 #define ASSERT_INTERRUPT(expression)                                                               \
     do {                                                                                           \
         if (!(expression)) {                                                                       \
-            while (1)                                                                              \
-                ;                                                                                  \
+            while (1) {                                                                            \
+            }                                                                                      \
         }                                                                                          \
     } while (0)
 
-void assert_handler(void);
+void assert_handler(uint16_t program_counter);
 
-#endif
+#endif  // ASSERT_HANDLER_H

--- a/src/common/trace.c
+++ b/src/common/trace.c
@@ -1,0 +1,23 @@
+#ifndef DISABLE_TRACE
+#include "common/trace.h"
+#include "common/assert_handler.h"
+#include "drivers/uart.h"
+#include "external/printf/printf.h"
+#include <stdbool.h>
+
+static bool initialized = false;
+void        trace_init(void) {
+    ASSERT(!initialized);
+    uart_init();
+    initialized = true;
+}
+
+void trace(const char* format, ...) {
+    ASSERT(initialized);
+    va_list args;
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+}
+
+#endif  // DISABLE_TRACE

--- a/src/common/trace.h
+++ b/src/common/trace.h
@@ -1,0 +1,14 @@
+#ifndef TRACE_H
+#define TRACE_H
+
+#define TRACE(fmt, ...) trace("%s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#ifndef DISABLE_TRACE
+void trace_init(void);
+void trace(const char* format, ...);
+/* #else
+#define trace_init() ;
+#define trace(fmt, ...) ; */
+#endif
+
+#endif

--- a/src/drivers/uart.h
+++ b/src/drivers/uart.h
@@ -4,4 +4,7 @@
 void uart_init(void);
 void _putchar(char c);
 
+// These functions should only be called by assert_handler
+void uart_init_assert(void);
+void uart_trace_assert(const char* string);
 #endif  // UART_H

--- a/src/drivers/uart.h
+++ b/src/drivers/uart.h
@@ -2,7 +2,6 @@
 #define UART_H
 
 void uart_init(void);
-// TODO: Replace with printf
-void uart_putchar_interrupt(char c);
-void uart_print_interrupt(const char* string);
+void _putchar(char c);
+
 #endif  // UART_H

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -5,6 +5,7 @@
 #include "drivers/mcu_init.h"
 #include "drivers/uart.h"
 #include <msp430.h>
+#include "common/trace.h"
 
 SUPPRESS_UNUSED
 static void test_setup(void) { 
@@ -142,7 +143,28 @@ static void test_uart(void)
     test_setup();
     uart_init();
     while(1){
-        uart_print_interrupt("UART working\n");
+        _putchar('U');
+        _putchar('A');
+        _putchar('R');
+        _putchar('T');
+        _putchar(' ');
+        _putchar('W');
+        _putchar('O');
+        _putchar('R');
+        _putchar('K');
+        _putchar('S');
+        _putchar('\n');
+        BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_trace(void)
+{
+    test_setup();
+    trace_init();
+    while(1){
+        TRACE("UART working! %d",2024);
         BUSY_WAIT_ms(1000);
     }
 }


### PR DESCRIPTION
The standard library printf implementation is not appropriate for a microcontroller. A microcontroller has no notion of stdout and the standard printf implementation has a big memory footprint. To get around this, use a more stripped-down external implementation, mpaland/printf, and include it as a git submodule (already included). Use this to implement a trace function that can send formatted strings.