### PR TITLE
feat(ir_remote): driver to decode IR signal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ SOURCES_WITH_HEADERS = \
 			 src/drivers/io.c \
 			 src/drivers/led.c \
 			 src/drivers/uart.c \
+			 src/drivers/ir_remote.c \
 			 src/app/drive.c  \
 			 src/app/enemy.c \
 			 external/printf/printf.c \

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -5,6 +5,7 @@
 #define SUPPRESS_UNUSED __attribute__((unused))
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 #define INTERRUPT_FUNCTION(vector) void __attribute__((interrupt(vector)))
+#define IS_ODD(x) (x & 1)
 
 #define CYCLES_1MHZ (1000000u)
 #define CYCLES_16MHZ (16u * CYCLES_1MHZ)

--- a/src/common/ring_buffer.c
+++ b/src/common/ring_buffer.c
@@ -8,6 +8,14 @@ void ring_buffer_put(struct ring_buffer* rb, uint8_t data) {
     if (rb->head == rb->size) {
         rb->head = 0;
     }
+
+    // If ring_buffer is full, remove oldest element
+    if (rb->head == rb->tail) {
+        rb->tail++;
+        if (rb->tail == rb->size) {
+            rb->tail = 0;
+        }
+    }
 }
 uint8_t ring_buffer_get(struct ring_buffer* rb) {
     const uint8_t data = rb->buffer[rb->tail];

--- a/src/common/trace.h
+++ b/src/common/trace.h
@@ -6,9 +6,9 @@
 #ifndef DISABLE_TRACE
 void trace_init(void);
 void trace(const char* format, ...);
-/* #else
+#else
 #define trace_init() ;
-#define trace(fmt, ...) ; */
+#define trace(fmt, ...) ;
 #endif
 
 #endif

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -81,8 +81,9 @@ static const struct io_config io_initial_config[IO_PORT_CNT * IO_PIN_CNT_PER_POR
      * Resistor: Not needed (pulled by transmitter/receiver)
      * Direction: Not applicable
      * Output: Not applicable */
-    [IO_UART_RXD] = {IO_SELECT_ALT3, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
-    [IO_UART_TXD] = {IO_SELECT_ALT3, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_UART_RXD]  = {IO_SELECT_ALT3, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_UART_TXD]  = {IO_SELECT_ALT3, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW},
+    [IO_IR_REMOTE] = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_LOW},
 
 #if defined(LAUNCHPAD)
     // Unused pins
@@ -91,7 +92,6 @@ static const struct io_config io_initial_config[IO_PORT_CNT * IO_PIN_CNT_PER_POR
     [IO_UNUSED_3]  = UNUSED_CONFIG,
     [IO_UNUSED_4]  = UNUSED_CONFIG,
     [IO_UNUSED_5]  = UNUSED_CONFIG,
-    [IO_UNUSED_6]  = UNUSED_CONFIG,
     [IO_UNUSED_7]  = UNUSED_CONFIG,
     [IO_UNUSED_8]  = UNUSED_CONFIG,
     [IO_UNUSED_9]  = UNUSED_CONFIG,
@@ -100,9 +100,6 @@ static const struct io_config io_initial_config[IO_PORT_CNT * IO_PIN_CNT_PER_POR
     [IO_UNUSED_12] = UNUSED_CONFIG,
     [IO_UNUSED_13] = UNUSED_CONFIG,
 #elif defined(NSUMO)
-    // Input (no resistor required according to datasheet of IR receiver)
-    [IO_IR_REMOTE] = {IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_LOW},
-
     /* I2C clock/data
      * Resistor: Disabled (there are external pull-up resistors)
      * Direction: Not applicable

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -27,7 +27,7 @@ typedef enum {
     IO_UNUSED_3  = IO_15,
     IO_UNUSED_4  = IO_16,
     IO_UNUSED_5  = IO_17,
-    IO_UNUSED_6  = IO_20,
+    IO_IR_REMOTE = IO_20,
     IO_UNUSED_7  = IO_21,
     IO_UNUSED_8  = IO_22,
     IO_UNUSED_9  = IO_23,

--- a/src/drivers/ir_remote.c
+++ b/src/drivers/ir_remote.c
@@ -1,0 +1,169 @@
+#include "drivers/ir_remote.h"
+#include "common/defines.h"
+#include "common/ring_buffer.h"
+#include "drivers/io.h"
+#include <assert.h>
+#include <msp430.h>
+#include <stdint.h>
+
+#define TIMER_DIVIDER_ID_3 (8u)
+#define TIMER_MC_MASK (0x0030)
+#define TICKS_PER_ms (CYCLES_16MHZ / TIMER_DIVIDER_ID_3 / 1000u)
+#define TIMER_INTERRUPT_ms (1u)
+#define TIMER_INTERRUPT_TICKS (TICKS_PER_ms * TIMER_INTERRUPT_ms)
+static_assert(TIMER_INTERRUPT_TICKS <= 0xFFFF, "Ticks too large");
+#define TIMER_TIMEOUT_ms (150u)
+#define IR_CMD_BUFFER_ELEM_CNT (10u)
+
+static uint8_t            buffer[IR_CMD_BUFFER_ELEM_CNT];
+static struct ring_buffer ir_cmd_buffer = {.buffer = buffer, .size = IR_CMD_BUFFER_ELEM_CNT};
+
+static union {
+    struct {
+        // cppcheck-suppress unusedStructMember
+        uint8_t cmd_inverted;
+        uint8_t cmd;
+        // cppcheck-suppress unusedStructMember
+        uint8_t addr_inverted;
+        // cppcheck-suppress unusedStructMember
+        uint8_t addr;
+    } decoded;
+    uint32_t raw;
+} ir_message;
+
+static uint8_t  timer_ms    = 0;
+static uint16_t pulse_count = 0;
+
+static void timer_init(void) {
+    /* Configure timer to trigger interrupt after TIMER_INTERRUPT_TICKS
+     * TASSEL_2: SMCLK
+     * ID_3: Input divider 8 */
+    TA1CTL   = TASSEL_2 + ID_3;
+    TA1CCR0  = TIMER_INTERRUPT_TICKS;
+    TA1CCTL0 = CCIE;
+}
+
+static void timer_start(void) {
+    // MC_1: Count upto CCR0
+    TA1CTL   = (TA1CTL & ~TIMER_MC_MASK) | MC_1 | TACLR;
+    timer_ms = 0;
+}
+
+static void timer_stop(void) {
+    // MC_0: Stop counter
+    TA1CTL = (TA1CTL & ~TIMER_MC_MASK) | MC_0;
+}
+
+static inline bool is_valid_pulse(uint16_t pulse, uint8_t ms) {
+    // Roughly sanity check if pulse arrived within expected time
+    if (pulse == 1) {
+        return ms == 0;
+    } else if (pulse == 2) {
+        return ms < 10;
+    } else if (3 <= pulse && pulse <= 34) {
+        return ms < 5;
+    } else if (pulse == 35) {
+        return ms < 50;
+    } else if (pulse == 36) {
+        return ms < 5;
+    } else if (pulse >= 37 && IS_ODD(pulse)) {
+        return ms < 110;
+    } else if (pulse >= 37) {  // even
+        return ms < 5;
+    } else {
+        return false;
+    }
+}
+
+static inline bool is_bit_pulse(uint16_t pulse) { return (3 <= pulse && pulse <= 34); }
+
+static inline bool is_message_pulse(uint16_t pulse) {
+    return pulse == 34 || (pulse > 36 && IS_ODD(pulse));
+}
+
+static void isr_pulse(void) {
+    timer_stop();
+    pulse_count++;
+
+    if (!is_valid_pulse(pulse_count, timer_ms)) {
+        // Assume start of new message
+        pulse_count    = 1;
+        ir_message.raw = 0;
+    } else if (is_bit_pulse(pulse_count)) {
+        ir_message.raw <<= 1;
+        ir_message.raw += (timer_ms >= 2) ? 1 : 0;
+    }
+
+    if (is_message_pulse(pulse_count)) {
+        ring_buffer_put(&ir_cmd_buffer, ir_message.decoded.cmd);
+    }
+    timer_start();
+}
+
+INTERRUPT_FUNCTION(TIMER1_A0_VECTOR) isr_timer_a0(void) {
+    if (timer_ms < TIMER_TIMEOUT_ms) {
+        timer_ms++;
+    } else {
+        timer_stop();
+        pulse_count    = 0;
+        timer_ms       = 0;
+        ir_message.raw = 0;
+    }
+}
+
+ir_cmd_e ir_remote_get_cmd(void) {
+    io_disable_interrupt(IO_IR_REMOTE);
+    ir_cmd_e cmd = IR_CMD_NONE;
+    if (!ring_buffer_empty(&ir_cmd_buffer)) {
+        cmd = ring_buffer_get(&ir_cmd_buffer);
+    }
+    io_enable_interrupt(IO_IR_REMOTE);
+    return cmd;
+}
+void ir_remote_init(void) {
+    io_configure_interrupt(IO_IR_REMOTE, IO_TRIGGER_FALLING, isr_pulse);
+    io_enable_interrupt(IO_IR_REMOTE);
+    timer_init();
+}
+
+const char* ir_remote_cmd_to_string(ir_cmd_e cmd) {
+    switch (cmd) {
+    case IR_CMD_0:
+        return "0";
+    case IR_CMD_1:
+        return "1";
+    case IR_CMD_2:
+        return "2";
+    case IR_CMD_3:
+        return "3";
+    case IR_CMD_4:
+        return "4";
+    case IR_CMD_5:
+        return "5";
+    case IR_CMD_6:
+        return "6";
+    case IR_CMD_7:
+        return "7";
+    case IR_CMD_8:
+        return "8";
+    case IR_CMD_9:
+        return "9";
+    case IR_CMD_STAR:
+        return "STAR";
+    case IR_CMD_HASH:
+        return "HASH";
+    case IR_CMD_UP:
+        return "UP";
+    case IR_CMD_DOWN:
+        return "DOWN";
+    case IR_CMD_LEFT:
+        return "LEFT";
+    case IR_CMD_RIGHT:
+        return "RIGHT";
+    case IR_CMD_OK:
+        return "OK";
+    case IR_CMD_NONE:
+        return "NONE";
+    }
+    return "UNKNOWN";
+}

--- a/src/drivers/ir_remote.h
+++ b/src/drivers/ir_remote.h
@@ -1,0 +1,32 @@
+#ifndef IR_REMOTE_H
+#define IR_REMOTE_H
+
+// A driver that decodes the commands sent to the IR receiver (NEC protocol)
+
+typedef enum {
+    IR_CMD_0     = 0x98,
+    IR_CMD_1     = 0xA2,
+    IR_CMD_2     = 0x62,
+    IR_CMD_3     = 0xE2,
+    IR_CMD_4     = 0x22,
+    IR_CMD_5     = 0x02,
+    IR_CMD_6     = 0xC2,
+    IR_CMD_7     = 0xE0,
+    IR_CMD_8     = 0xA8,
+    IR_CMD_9     = 0x90,
+    IR_CMD_STAR  = 0x68,
+    IR_CMD_HASH  = 0xB0,
+    IR_CMD_UP    = 0x18,
+    IR_CMD_DOWN  = 0x4A,
+    IR_CMD_LEFT  = 0x10,
+    IR_CMD_RIGHT = 0x5A,
+    IR_CMD_OK    = 0x38,
+    IR_CMD_NONE  = 0xFF
+} ir_cmd_e;
+
+void     ir_remote_init(void);
+ir_cmd_e ir_remote_get_cmd(void);
+
+const char* ir_remote_cmd_to_string(ir_cmd_e cmd);
+
+#endif  // IR_REMOTE_H

--- a/src/drivers/uart.c
+++ b/src/drivers/uart.c
@@ -106,6 +106,10 @@ void        uart_init(void) {
 
 // mpaland/printf needs this to be named _putchar
 void _putchar(char c) {
+    // Some terminals expect line feed (\r) after carriage return (\n) for proper new line
+    if (c == '\n') {
+        _putchar('\r');
+    }
     // Poll if full
     while (ring_buffer_full(&tx_buffer)) {
     }
@@ -117,10 +121,6 @@ void _putchar(char c) {
         uart_tx_start();
     }
     uart_tx_enable_interrupt();
-    // Some terminals expect line feed (\r) after carriage return (\n) for proper new line
-    if (c == '\n') {
-        _putchar('\r');
-    }
 }
 
 void uart_init_assert(void) {
@@ -129,14 +129,12 @@ void uart_init_assert(void) {
 }
 
 void uart_putchar_polling(char c) {
+    if (c == '\n') {
+        uart_putchar_polling('\r');
+    }
     while (!(IFG2 & UCA0TXIFG)) {
     }
     UCA0TXBUF = c;
-    if (c == '\n') {
-        while (!(IFG2 & UCA0TXIFG)) {
-        }
-        uart_putchar_polling('\r');
-    }
 }
 
 void uart_trace_assert(const char* string) {

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -4,6 +4,7 @@
 #include "drivers/led.h"
 #include "drivers/mcu_init.h"
 #include "drivers/uart.h"
+#include "drivers/ir_remote.h"
 #include <msp430.h>
 #include "common/trace.h"
 
@@ -166,6 +167,18 @@ static void test_trace(void)
     while(1){
         TRACE("UART working! %d",2024);
         BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_ir_remote(void)
+{
+    test_setup();
+    trace_init();
+    ir_remote_init();
+    while(1){
+        TRACE("Command %s", ir_remote_cmd_to_string(ir_remote_get_cmd()));
+        BUSY_WAIT_ms(250);
     }
 }
 


### PR DESCRIPTION
The robot must be able to decode a start signal sent at each match start. This signal is sent from an IR transmitter and is picket up by the IR receiver on board. Implement a driver that decodes the signal by measuring the time between the pulses on the GPIO connected to the IR receiver. Besides the start signal, also use this functionality to control the robot with a remote control, which is useful during development. Simplify the implementation by just tracking the falling edges. Also in uart transmission '\r' should be send first when '\n' is sent. Changed the implementation for it.